### PR TITLE
Switch default cadence endpoint from 127.0.0.1 to localhost

### DIFF
--- a/client_main/main.go
+++ b/client_main/main.go
@@ -112,7 +112,7 @@ func __run__(_args []string) {
 	fs.StringVar(&args, "args", "[]", "Function's positional arguments. Format: JSON array. Example: '[\"foo\", 100, true]'")
 	fs.StringVar(&kwargs, "kwargs", "[]", "Function's keyword arguments.Format: JSON array or arrays. Example: [[\"country_code\", \"US\"], [\"item_id\", 101]]")
 	fs.Var(&env, "env", "Environment variables to be set for the run")
-	fs.StringVar(&cadenceURL, "cadence-url", getEnv("CADENCE_URL", "grpc://127.0.0.1:7833/cadence-frontend/default/default"), "")
+	fs.StringVar(&cadenceURL, "cadence-url", getEnv("CADENCE_URL", "grpc://localhost:7833/cadence-frontend/default/default"), "")
 
 	if err := fs.Parse(_args); err != nil {
 		log.Fatal(err)

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ func (r *_Options) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&r.CadenceURL,
 		"cadence-url",
-		"grpc://127.0.0.1:7833",
+		"grpc://localhost:7833",
 		"Cadence connection URL",
 	)
 	fs.StringVar(


### PR DESCRIPTION
When Cadence is run locally via default docker-compose setup ([ref](https://github.com/cadence-workflow/cadence/tree/master/docker#quickstart-for-development-with-local-cadence-server)) the grpc endpoint is not reachable via 127.0.0.1:7833. Instead localhost:7833 works. 