### PR TITLE
Update tally to 3.5.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.10.0
-	github.com/uber-go/tally v3.5.10+incompatible
+	github.com/uber-go/tally v3.5.8+incompatible
 	go.starlark.net v0.0.0-20241125201518-c05ff208a98f
 	go.uber.org/cadence v1.2.9
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq
 github.com/uber-go/mapdecode v1.0.0 h1:euUEFM9KnuCa1OBixz1xM+FIXmpixyay5DLymceOVrU=
 github.com/uber-go/mapdecode v1.0.0/go.mod h1:b5nP15FwXTgpjTjeA9A2uTHXV5UJCl4arwKpP0FP1Hw=
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
-github.com/uber-go/tally v3.5.10+incompatible h1:PDkAMvnVYOdJtvyCZQURmHtOakCiWAWFVKejrrvOMBo=
-github.com/uber-go/tally v3.5.10+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
+github.com/uber-go/tally v3.5.8+incompatible h1:Z2vK6ib6G/r6bAGu7lAI/98cLPLUOtdHrY2bBikk4wg=
+github.com/uber-go/tally v3.5.8+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=


### PR DESCRIPTION
What type of PR is this? (check all applicable)

 Refactor
 Feature
 Bug Fix
 [x] Optimization
 Documentation Update
What changed?
Downgrade the tally to 3.5.8 for better adoption. 3.5.10 has new features that are not backward compatible. 

One of the key changes:
Version 3.5.10 introduces new features that are not backward compatible. Specifically, the [omitCardinalityMetrics](https://github.com/uber-go/tally/blob/v3.5.10/scope_registry.go) field must be set to "true" to prevent internal metrics from being published. If users expect only their own metrics to be published, this change can disrupt testing and potentially result in a large volume of unnecessary metrics being emitted.
