### PR TITLE
Support __codec__ Preservation While Safely Constructing Dataclass

### DIFF
--- a/star/codec.go
+++ b/star/codec.go
@@ -156,6 +156,9 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 		// Create a shallow copy without __codec__
 		tempDict := starlark.NewDict(dict.Len() - 1)
 		for _, item := range dict.Items() {
+			if len(item) != 2 {
+				continue
+			}
 			if keyStr, ok := item[0].(starlark.String); ok && keyStr == "__codec__" {
 				continue
 			}

--- a/star/codec.go
+++ b/star/codec.go
@@ -142,10 +142,10 @@ func Decode(line []byte, out any) (err error) {
 	return nil
 }
 
-// codecDictReplacer replaces dictionaries with __codec__ key with an appropriate starlark object, such us Dataclass.
+// codecDictReplacer replaces special "codec dictionaries" with custom starlark objects, such us Dataclass.
 // See also: replaceDict
 func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
-	codec, found, err := dict.Delete(starlark.String("__codec__"))
+	codec, found, err := dict.Get(starlark.String("__codec__"))
 	if err != nil {
 		return nil, err
 	}
@@ -153,14 +153,14 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 		return dict, nil
 	}
 	if codec == starlark.String("dataclass") {
-		return NewDataclassFromDict(dict), nil
+		return &Dataclass{Dict: dict}, nil
 	}
 	return dict, nil
 }
 
 // replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with
-// a value returned by the replacer function. This is used to enable custom JSON decoding, to support Dataclass.
-// The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
+// a value returned by the replacer function. This is used to enable custom JSON decoding, for example to support
+// Dataclass. The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
 // See also: codecDictReplacer
 func replaceDict(value starlark.Value, replacer func(d *starlark.Dict) (starlark.Value, error)) (starlark.Value, error) {
 	switch value := value.(type) {

--- a/star/codec.go
+++ b/star/codec.go
@@ -153,7 +153,7 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 		return dict, nil
 	}
 	if codec == starlark.String("dataclass") {
-		return &Dataclass{Dict: dict}, nil
+		return NewDataclassFromDict(dict), nil
 	}
 	return dict, nil
 }

--- a/star/codec.go
+++ b/star/codec.go
@@ -166,9 +166,9 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 	return dict, nil
 }
 
-// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with	// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with
-// a value returned by the replacer function. This is used to enable custom JSON decoding, to support Dataclass.	// a value returned by the replacer function. This is used to enable custom JSON decoding, for example to support
-// The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders	// Dataclass. The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
+// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with
+// a value returned by the replacer function. This is used to enable custom JSON decoding, to support Dataclass.
+// The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
 // See also: codecDictReplacer
 func replaceDict(value starlark.Value, replacer func(d *starlark.Dict) (starlark.Value, error)) (starlark.Value, error) {
 	switch value := value.(type) {

--- a/star/codec.go
+++ b/star/codec.go
@@ -152,8 +152,16 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 	if !found {
 		return dict, nil
 	}
-	if codec == starlark.String("dataclass") {
-		return NewDataclassFromDict(dict), nil
+	if codec == starlark.String(DataclassType) {
+		// Create a shallow copy without __codec__
+		tempDict := starlark.NewDict(dict.Len() - 1)
+		for _, item := range dict.Items() {
+			if keyStr, ok := item[0].(starlark.String); ok && keyStr == "__codec__" {
+				continue
+			}
+			_ = tempDict.SetKey(item[0], item[1])
+		}
+		return NewDataclassFromDict(tempDict), nil
 	}
 	return dict, nil
 }

--- a/star/codec.go
+++ b/star/codec.go
@@ -158,9 +158,9 @@ func codecDictReplacer(dict *starlark.Dict) (starlark.Value, error) {
 	return dict, nil
 }
 
-// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with
-// a value returned by the replacer function. This is used to enable custom JSON decoding, for example to support
-// Dataclass. The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
+// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with	// replaceDict traverses JSON decoded data structure (starlark.Value) and replaces each JSON object (starlark.Dict) with
+// a value returned by the replacer function. This is used to enable custom JSON decoding, to support Dataclass.	// a value returned by the replacer function. This is used to enable custom JSON decoding, for example to support
+// The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders	// Dataclass. The idea is similar to Python's JSON decoder object_hook https://docs.python.org/3/library/json.html#encoders-and-decoders
 // See also: codecDictReplacer
 func replaceDict(value starlark.Value, replacer func(d *starlark.Dict) (starlark.Value, error)) (starlark.Value, error) {
 	switch value := value.(type) {

--- a/star/codec_test.go
+++ b/star/codec_test.go
@@ -46,11 +46,11 @@ func TestEncode(t *testing.T) {
 
 	t.Run("dataclass", func(t *testing.T) {
 		// bytes are encoded as quoted base64 string
-		input := &starlark.Dict{}
-		require.NoError(t, input.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
-		require.NoError(t, input.SetKey(starlark.String("pi"), starlark.Float(3.14)))
-		require.NoError(t, input.SetKey(starlark.String("test"), starlark.True))
-		res, err := Encode(&Dataclass{Dict: input})
+		input := starlark.StringDict{
+			"pi":   starlark.Float(3.14),
+			"test": starlark.True,
+		}
+		res, err := Encode(NewDataclass(input))
 		require.NoError(t, err)
 		require.Equal(t, []byte(`{"__codec__":"dataclass","pi":3.14,"test":true}`), res)
 	})
@@ -243,11 +243,11 @@ func TestDecode(t *testing.T) {
 		// value can accept any starlark type
 		var out starlark.Value
 		require.NoError(t, Decode([]byte(`{"__codec__":"dataclass","pi":3.14,"test":true}`), &out))
-		expected := &starlark.Dict{}
-		require.NoError(t, expected.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
-		require.NoError(t, expected.SetKey(starlark.String("pi"), starlark.Float(3.14)))
-		require.NoError(t, expected.SetKey(starlark.String("test"), starlark.True))
-		require.Equal(t, &Dataclass{Dict: expected}, out)
+		expected := starlark.StringDict{
+			"pi":   starlark.Float(3.14),
+			"test": starlark.True,
+		}
+		require.Equal(t, NewDataclass(expected), out)
 	})
 
 	t.Run("go-interface", func(t *testing.T) {

--- a/star/codec_test.go
+++ b/star/codec_test.go
@@ -259,3 +259,24 @@ func TestDecode(t *testing.T) {
 		require.True(t, ok, fmt.Sprintf("bad error type: %T", err))
 	})
 }
+
+func TestCodecDictReplacer_PreservesCodecKey(t *testing.T) {
+	dict := &starlark.Dict{}
+	require.NoError(t, dict.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
+	require.NoError(t, dict.SetKey(starlark.String("pi"), starlark.Float(3.14)))
+	require.NoError(t, dict.SetKey(starlark.String("test"), starlark.True))
+
+	// Run through the replacer
+	res, err := codecDictReplacer(dict)
+	require.NoError(t, err)
+
+	// Should return a Dataclass
+	_, ok := res.(Dataclass)
+	require.True(t, ok, "result should be a Dataclass")
+
+	// Original dict should still contain __codec__
+	codecVal, found, err := dict.Get(starlark.String("__codec__"))
+	require.NoError(t, err)
+	require.True(t, found, "__codec__ should still be present in the original dict")
+	require.Equal(t, starlark.String("dataclass"), codecVal)
+}

--- a/star/codec_test.go
+++ b/star/codec_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestEncode(t *testing.T) {
+func TestCodec(t *testing.T) {
 
 	t.Run("bytes", func(t *testing.T) {
 		// bytes are encoded as quoted base64 string

--- a/star/codec_test.go
+++ b/star/codec_test.go
@@ -46,11 +46,11 @@ func TestEncode(t *testing.T) {
 
 	t.Run("dataclass", func(t *testing.T) {
 		// bytes are encoded as quoted base64 string
-		input := starlark.StringDict{
-			"pi":   starlark.Float(3.14),
-			"test": starlark.True,
-		}
-		res, err := Encode(NewDataclass(input))
+		input := &starlark.Dict{}
+		require.NoError(t, input.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
+		require.NoError(t, input.SetKey(starlark.String("pi"), starlark.Float(3.14)))
+		require.NoError(t, input.SetKey(starlark.String("test"), starlark.True))
+		res, err := Encode(&Dataclass{Dict: input})
 		require.NoError(t, err)
 		require.Equal(t, []byte(`{"__codec__":"dataclass","pi":3.14,"test":true}`), res)
 	})
@@ -243,11 +243,11 @@ func TestDecode(t *testing.T) {
 		// value can accept any starlark type
 		var out starlark.Value
 		require.NoError(t, Decode([]byte(`{"__codec__":"dataclass","pi":3.14,"test":true}`), &out))
-		expected := starlark.StringDict{
-			"pi":   starlark.Float(3.14),
-			"test": starlark.True,
-		}
-		require.Equal(t, NewDataclass(expected), out)
+		expected := &starlark.Dict{}
+		require.NoError(t, expected.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
+		require.NoError(t, expected.SetKey(starlark.String("pi"), starlark.Float(3.14)))
+		require.NoError(t, expected.SetKey(starlark.String("test"), starlark.True))
+		require.Equal(t, &Dataclass{Dict: expected}, out)
 	})
 
 	t.Run("go-interface", func(t *testing.T) {

--- a/star/codec_test.go
+++ b/star/codec_test.go
@@ -258,25 +258,25 @@ func TestDecode(t *testing.T) {
 		_, ok := err.(UnsupportedTypeError)
 		require.True(t, ok, fmt.Sprintf("bad error type: %T", err))
 	})
-}
 
-func TestCodecDictReplacer_PreservesCodecKey(t *testing.T) {
-	dict := &starlark.Dict{}
-	require.NoError(t, dict.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
-	require.NoError(t, dict.SetKey(starlark.String("pi"), starlark.Float(3.14)))
-	require.NoError(t, dict.SetKey(starlark.String("test"), starlark.True))
+	t.Run("preserves codec key", func(t *testing.T) {
+		dict := &starlark.Dict{}
+		require.NoError(t, dict.SetKey(starlark.String("__codec__"), starlark.String("dataclass")))
+		require.NoError(t, dict.SetKey(starlark.String("pi"), starlark.Float(3.14)))
+		require.NoError(t, dict.SetKey(starlark.String("test"), starlark.True))
 
-	// Run through the replacer
-	res, err := codecDictReplacer(dict)
-	require.NoError(t, err)
+		// Run through the replacer
+		res, err := codecDictReplacer(dict)
+		require.NoError(t, err)
 
-	// Should return a Dataclass
-	_, ok := res.(Dataclass)
-	require.True(t, ok, "result should be a Dataclass")
+		// Should return a Dataclass
+		_, ok := res.(Dataclass)
+		require.True(t, ok, "result should be a Dataclass")
 
-	// Original dict should still contain __codec__
-	codecVal, found, err := dict.Get(starlark.String("__codec__"))
-	require.NoError(t, err)
-	require.True(t, found, "__codec__ should still be present in the original dict")
-	require.Equal(t, starlark.String("dataclass"), codecVal)
+		// Original dict should still contain __codec__
+		codecVal, found, err := dict.Get(starlark.String("__codec__"))
+		require.NoError(t, err)
+		require.True(t, found, "__codec__ should still be present in the original dict")
+		require.Equal(t, starlark.String("dataclass"), codecVal)
+	})
 }

--- a/star/dataclass.go
+++ b/star/dataclass.go
@@ -7,59 +7,80 @@ import (
 	"go.starlark.net/syntax"
 )
 
-type Dataclass struct {
-	Dict *starlark.Dict
+const DataclassType = "dataclass"
+
+var DataclassConstructor = starlark.NewBuiltin(DataclassType, MakeDataclass)
+
+type Dataclass interface {
+	starlark.Comparable
+	starlark.HasSetField
+	json.Marshaler
 }
 
-var _ starlark.Comparable = (*Dataclass)(nil)
-var _ starlark.HasSetField = (*Dataclass)(nil)
-var _ json.Marshaler = (*Dataclass)(nil)
-
-func (r *Dataclass) String() string        { return r.Dict.String() }
-func (r *Dataclass) Type() string          { return r.Dict.Type() }
-func (r *Dataclass) Freeze()               { r.Dict.Freeze() }
-func (r *Dataclass) Truth() starlark.Bool  { return r.Dict.Truth() }
-func (r *Dataclass) Hash() (uint32, error) { return r.Dict.Hash() }
-
-func (r *Dataclass) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
-	y := y_.(*Dataclass).Dict
-	return r.Dict.CompareSameType(op, y, depth)
+type _Dataclass struct {
+	attrs starlark.StringDict
 }
 
-func (r *Dataclass) Attr(name string) (starlark.Value, error) {
-	if name == "__dict__" {
-		return r.Dict, nil
+var _ Dataclass = (*_Dataclass)(nil)
+
+func NewDataclass(attrs starlark.StringDict) Dataclass {
+	attrsCopy := starlark.StringDict{}
+	for k, v := range attrs {
+		if k == "__codec__" {
+			// __codec__ is reserved for the internal encoding use
+			err := fmt.Errorf("__codec__ is reserved")
+			panic(err)
+		}
+		attrsCopy[k] = v
 	}
-	v, found, err := r.Dict.Get(starlark.String(name))
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, nil
-	}
-	return v, nil
+	return &_Dataclass{attrs: attrsCopy}
 }
 
-func (r *Dataclass) AttrNames() []string {
-	attrs := make([]string, r.Dict.Len())
-	for i, key := range r.Dict.Keys() {
-		attrs[i] = string(key.(starlark.String))
-	}
-	return attrs
+func NewDataclassFromDict(dict *starlark.Dict) Dataclass {
+	attrs := KeywordsToStringDict(dict.Items())
+	return NewDataclass(attrs)
 }
 
-func (r *Dataclass) SetField(name string, val starlark.Value) error {
-	k := starlark.String(name)
-	_, found, err := r.Dict.Get(k)
-	if err != nil {
-		return err
+func (r *_Dataclass) String() string                           { return fmt.Sprintf("<%s %s>", DataclassType, r.attrs.String()) }
+func (r *_Dataclass) Type() string                             { return DataclassType }
+func (r *_Dataclass) Freeze()                                  { r.attrs.Freeze() }
+func (r *_Dataclass) Truth() starlark.Bool                     { return len(r.attrs) > 0 }
+func (r *_Dataclass) Hash() (uint32, error)                    { return 0, fmt.Errorf("unhashable: %s", DataclassType) }
+func (r *_Dataclass) Attr(name string) (starlark.Value, error) { return r.attrs[name], nil }
+func (r *_Dataclass) AttrNames() []string                      { return r.attrs.Keys() }
+
+func (r *_Dataclass) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
+	y := y_.(*_Dataclass)
+	switch op {
+	case syntax.EQL:
+		ok, err := StringDictEqualDepth(r.attrs, y.attrs, depth)
+		return ok, err
+	case syntax.NEQ:
+		ok, err := StringDictEqualDepth(r.attrs, y.attrs, depth)
+		return !ok, err
+	default:
+		return false, fmt.Errorf("%s %s %s not implemented", r.Type(), op, y.Type())
 	}
-	if !found {
+}
+
+func (r *_Dataclass) SetField(name string, val starlark.Value) error {
+	if _, found := r.attrs[name]; !found {
 		return fmt.Errorf("attribute not found: %s", name)
 	}
-	return r.Dict.SetKey(k, val)
+	r.attrs[name] = val
+	return nil
 }
 
-func (r *Dataclass) MarshalJSON() ([]byte, error) {
-	return Encode(r.Dict)
+func (r *_Dataclass) MarshalJSON() ([]byte, error) {
+	dict := StringDictToDict(r.attrs)
+	SetStringKey(dict, "__codec__", starlark.String(DataclassType))
+	return Encode(dict)
+}
+
+func MakeDataclass(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if args.Len() > 0 {
+		return nil, fmt.Errorf("%s() takes no positional arguments", DataclassType)
+	}
+	attrs := KeywordsToStringDict(kwargs)
+	return NewDataclass(attrs), nil
 }

--- a/star/dataclass.go
+++ b/star/dataclass.go
@@ -7,80 +7,59 @@ import (
 	"go.starlark.net/syntax"
 )
 
-const DataclassType = "dataclass"
-
-var DataclassConstructor = starlark.NewBuiltin(DataclassType, MakeDataclass)
-
-type Dataclass interface {
-	starlark.Comparable
-	starlark.HasSetField
-	json.Marshaler
+type Dataclass struct {
+	Dict *starlark.Dict
 }
 
-type _Dataclass struct {
-	attrs starlark.StringDict
+var _ starlark.Comparable = (*Dataclass)(nil)
+var _ starlark.HasSetField = (*Dataclass)(nil)
+var _ json.Marshaler = (*Dataclass)(nil)
+
+func (r *Dataclass) String() string        { return r.Dict.String() }
+func (r *Dataclass) Type() string          { return r.Dict.Type() }
+func (r *Dataclass) Freeze()               { r.Dict.Freeze() }
+func (r *Dataclass) Truth() starlark.Bool  { return r.Dict.Truth() }
+func (r *Dataclass) Hash() (uint32, error) { return r.Dict.Hash() }
+
+func (r *Dataclass) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
+	y := y_.(*Dataclass).Dict
+	return r.Dict.CompareSameType(op, y, depth)
 }
 
-var _ Dataclass = (*_Dataclass)(nil)
-
-func NewDataclass(attrs starlark.StringDict) Dataclass {
-	attrsCopy := starlark.StringDict{}
-	for k, v := range attrs {
-		if k == "__codec__" {
-			// __codec__ is reserved for the internal encoding use
-			err := fmt.Errorf("__codec__ is reserved")
-			panic(err)
-		}
-		attrsCopy[k] = v
+func (r *Dataclass) Attr(name string) (starlark.Value, error) {
+	if name == "__dict__" {
+		return r.Dict, nil
 	}
-	return &_Dataclass{attrs: attrsCopy}
-}
-
-func NewDataclassFromDict(dict *starlark.Dict) Dataclass {
-	attrs := KeywordsToStringDict(dict.Items())
-	return NewDataclass(attrs)
-}
-
-func (r *_Dataclass) String() string                           { return fmt.Sprintf("<%s %s>", DataclassType, r.attrs.String()) }
-func (r *_Dataclass) Type() string                             { return DataclassType }
-func (r *_Dataclass) Freeze()                                  { r.attrs.Freeze() }
-func (r *_Dataclass) Truth() starlark.Bool                     { return len(r.attrs) > 0 }
-func (r *_Dataclass) Hash() (uint32, error)                    { return 0, fmt.Errorf("unhashable: %s", DataclassType) }
-func (r *_Dataclass) Attr(name string) (starlark.Value, error) { return r.attrs[name], nil }
-func (r *_Dataclass) AttrNames() []string                      { return r.attrs.Keys() }
-
-func (r *_Dataclass) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
-	y := y_.(*_Dataclass)
-	switch op {
-	case syntax.EQL:
-		ok, err := StringDictEqualDepth(r.attrs, y.attrs, depth)
-		return ok, err
-	case syntax.NEQ:
-		ok, err := StringDictEqualDepth(r.attrs, y.attrs, depth)
-		return !ok, err
-	default:
-		return false, fmt.Errorf("%s %s %s not implemented", r.Type(), op, y.Type())
+	v, found, err := r.Dict.Get(starlark.String(name))
+	if err != nil {
+		return nil, err
 	}
+	if !found {
+		return nil, nil
+	}
+	return v, nil
 }
 
-func (r *_Dataclass) SetField(name string, val starlark.Value) error {
-	if _, found := r.attrs[name]; !found {
+func (r *Dataclass) AttrNames() []string {
+	attrs := make([]string, r.Dict.Len())
+	for i, key := range r.Dict.Keys() {
+		attrs[i] = string(key.(starlark.String))
+	}
+	return attrs
+}
+
+func (r *Dataclass) SetField(name string, val starlark.Value) error {
+	k := starlark.String(name)
+	_, found, err := r.Dict.Get(k)
+	if err != nil {
+		return err
+	}
+	if !found {
 		return fmt.Errorf("attribute not found: %s", name)
 	}
-	r.attrs[name] = val
-	return nil
+	return r.Dict.SetKey(k, val)
 }
 
-func (r *_Dataclass) MarshalJSON() ([]byte, error) {
-	dict := StringDictToDict(r.attrs)
-	SetStringKey(dict, "__codec__", starlark.String(DataclassType))
-	return Encode(dict)
-}
-
-func MakeDataclass(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if args.Len() > 0 {
-		return nil, fmt.Errorf("%s() takes no positional arguments", DataclassType)
-	}
-	attrs := KeywordsToStringDict(kwargs)
-	return NewDataclass(attrs), nil
+func (r *Dataclass) MarshalJSON() ([]byte, error) {
+	return Encode(r.Dict)
 }


### PR DESCRIPTION
This PR updates the codecDictReplacer logic to safely handle the reserved "__codec__" field during Dataclass construction without mutating the original starlark.Dict. Previously, we used dict.Delete("__codec__") to remove this field before constructing a Dataclass, which resulted in loss of this metadata for downstream consumers (e.g., serialization or transport layers).

In the new implementation:

We preserve the original dict, including the __codec__ field.

We construct a shallow clone of the dict excluding __codec__ only for NewDataclassFromDict, avoiding the panic caused by passing a reserved field.

This change maintains the integrity of the dataclass schema, while still allowing downstream systems to access __codec__ as metadata (e.g., for codec dispatch or type tracking).

This makes the Dataclass integration safer and more interoperable across services, especially in pipelines that rely on the presence of "__codec__" for decoding, logging, or external transformation.