### PR TITLE
Configurable dataclass codecs

### DIFF
--- a/star/utils.go
+++ b/star/utils.go
@@ -58,12 +58,6 @@ func StringDictToDict(a starlark.StringDict) *starlark.Dict {
 	return d
 }
 
-func SetStringKey(d *starlark.Dict, key string, value starlark.Value) {
-	if err := d.SetKey(starlark.String(key), value); err != nil {
-		panic(err)
-	}
-}
-
 func StringDictEqualDepth(x, y starlark.StringDict, depth int) (bool, error) {
 	if len(x) != len(y) {
 		return false, nil

--- a/test/testdata/dataclass_test.star
+++ b/test/testdata/dataclass_test.star
@@ -5,7 +5,7 @@ def test_attributes():
         p1 = "v1",
         p2 = "v2",
     )
-    t.equal(["p1", "p2"], dir(o1))
+    t.equal(["__codec__", "p1", "p2"], dir(o1))
     t.true(hasattr(o1, "p1"))
     t.true(hasattr(o1, "p2"))
     t.false(hasattr(o1, "p3"))
@@ -52,8 +52,8 @@ def test_comparison_operators():
 
 def test_empty():
     o = dataclass()
-    t.equal([], dir(o))
-    t.false(bool(o))
+    t.equal(["__codec__"], dir(o))
+    t.true(bool(o))
 
 def test_builtin_methods():
     o1 = dataclass(
@@ -61,4 +61,4 @@ def test_builtin_methods():
         p2 = "v2",
     )
     t.equal("dataclass", type(o1))
-    t.equal('<dataclass {p1: "v1", p2: "v2"}>', str(o1))
+    t.equal('<dataclass {__codec__: "dataclass", p1: "v1", p2: "v2"}>', str(o1))


### PR DESCRIPTION
### DataclassCodecs

Added the DataclassCodecs variable, which contains a set of codecs that determine whether a dictionary should be wrapped in a Dataclass object during the decoding process.

By default, DataclassCodecs includes only the "dataclass" codec. Users can add additional codecs, thus instructing the Starlark interpreter to treat the decoded dictionary object as a Dataclass. For example, we have a use case in Uniflow that requires us to maintain two values in DataclassCodecs - "dataclass" and "pydantic."

### Minor Clean Up

Removed the `SetStringKey` utility method from `star/utils.go`.