### PR TITLE
Update processing error to use error() as default error instead of customError

### DIFF
--- a/internal/internal_temporal.go
+++ b/internal/internal_temporal.go
@@ -322,7 +322,20 @@ func (w TemporalWorkflow) WithWorkflowTaskList(ctx Context, name string) Context
 }
 
 func (w TemporalWorkflow) NewCustomError(reason string, details ...interface{}) CustomError {
-	err := temporal.NewApplicationError(reason, reason, details...)
+	var message = reason
+
+	// Check if the first detail is a map[string]interface{} and has key "error"
+	if len(details) > 0 {
+		if detailMap, ok := details[0].(map[string]interface{}); ok {
+			if errVal, exists := detailMap["error"]; exists {
+				if str, ok := errVal.(string); ok {
+					message = str
+				}
+			}
+		}
+	}
+
+	err := temporal.NewApplicationError(message, reason, details...)
 	return &TemporalCustomError{
 		ApplicationError: *err.(*temporal.ApplicationError),
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -265,7 +265,7 @@ func (r *Service) processError(ctx workflow.Context, err error) error {
 		details["backtrace"] = evalErr.Backtrace()
 	}
 	var workflowErr workflow.CustomError
-	var reason = yarpcerrors.CodeUnknown.String()
+	var reason = err.Error()
 	if errors.As(err, &workflowErr) {
 		reason = workflowErr.Reason()
 		if workflowErr.HasDetails() {

--- a/service/service.go
+++ b/service/service.go
@@ -265,7 +265,7 @@ func (r *Service) processError(ctx workflow.Context, err error) error {
 		details["backtrace"] = evalErr.Backtrace()
 	}
 	var workflowErr workflow.CustomError
-	var reason = err.Error()
+	var reason = yarpcerrors.CodeUnknown.String()
 	if errors.As(err, &workflowErr) {
 		reason = workflowErr.Reason()
 		if workflowErr.HasDetails() {

--- a/test/temporal_integration_test.go
+++ b/test/temporal_integration_test.go
@@ -82,9 +82,8 @@ func (r *TempSuite) TestAtExit() {
 
 		var appError *temporalsdk.ApplicationError
 		require.True(errors.As(err, &appError))
-		// Commenting out flaky tests
-		//require.Equal("assert\nExpected : 200\nActual   : 404 (type: assert\nExpected : 200\nActual   : 404, retryable: true)", appError.Message())
-		//require.Equal("TemporalCustomError", appError.Type())
+		require.Equal("fail: injected error", appError.Message())
+		require.Equal("TemporalCustomError", appError.Type())
 	})
 
 	// make sure the test run did not leak any resources on the test server


### PR DESCRIPTION
This is required by using Temporal, Temporal doesn't have customError, so it won't show the details.  Cadence doens't have this problem.