### PR TITLE
Add ability to alter execution time via STARLARK_TIME env

### DIFF
--- a/ext/lang.go
+++ b/ext/lang.go
@@ -1,0 +1,10 @@
+package ext
+
+// Must function returns the value if err is nil, otherwise it panics.
+// Useful for simplifying error handling in situations where errors are unexpected or unrecoverable.
+func Must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return val
+}

--- a/plugin/time/plugin.go
+++ b/plugin/time/plugin.go
@@ -18,8 +18,8 @@ func (r *plugin) ID() string {
 	return pluginID
 }
 
-func (r *plugin) Create(_ service.RunInfo) starlark.Value {
-	return &Module{}
+func (r *plugin) Create(info service.RunInfo) starlark.Value {
+	return NewModule(info)
 }
 
 func (r *plugin) Register(registry worker.Registry) {}

--- a/service/plugin.go
+++ b/service/plugin.go
@@ -1,10 +1,25 @@
 package service
 
 import (
+	"fmt"
 	"github.com/cadence-workflow/starlark-worker/worker"
 	"github.com/cadence-workflow/starlark-worker/workflow"
 	"go.starlark.net/starlark"
+	"strconv"
+	"strings"
+	"time"
 )
+
+// STARLARK_TIME is an environment variable used to alter the time for the Starlark script execution.
+// This feature supports backfill scenarios, enabling users to execute their Starlark scripts as if they were triggered
+// at a specific time in the past.
+//
+// The STARLARK_TIME value must be in the following format: 'unix:<value>'.
+// Here, "unix" is the scheme, and <value> is a number of seconds since the epoch, commonly known as Unix time.
+// Currently, we only support Unix time format. However, we can add support for other formats, like RFC 3339.
+//
+// See RunInfo.GetEffectiveTime for usage details.
+const STARLARK_TIME = "STARLARK_TIME"
 
 // IPlugin plugin factory interface
 // Plugin instances are created on startup and are used to create starlark.Value instances per workflow execution
@@ -23,4 +38,35 @@ type IPlugin interface {
 type RunInfo struct {
 	Info    workflow.IInfo
 	Environ *starlark.Dict
+	SysTime time.Time // SysTime represents the actual wall-clock time when the workflow execution started.
+}
+
+// GetEffectiveTime returns the effective time when the workflow execution started.
+// By default, it corresponds to SysTime, i.e., actual wall-clock time.
+// However, users have the option to alter the time via the STARLARK_TIME environment variable.
+// In this case, the function returns altered time as defined by the STARLARK_TIME environment variable.
+func (r *RunInfo) GetEffectiveTime() (time.Time, error) {
+	v, ok, _ := r.Environ.Get(starlark.String(STARLARK_TIME))
+	if !ok {
+		return r.SysTime, nil // Return system time if STARLARK_TIME is undefined.
+	}
+	// Parse STARLARK_TIME. Expected format: scheme:value
+	parts := strings.SplitN(v.(starlark.String).GoString(), ":", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("invalid %s env; expected format: 'scheme:value'; actual value: '%s'", STARLARK_TIME, v)
+		return time.Time{}, err
+	}
+	scheme := parts[0]
+	rest := parts[1]
+	switch scheme {
+	case "unix":
+		seconds, err := strconv.ParseInt(rest, 10, 64)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return time.Unix(seconds, 0), nil
+	default:
+		err := fmt.Errorf("unsupported scheme: %s", scheme)
+		return time.Time{}, err
+	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -175,6 +175,7 @@ func (r *Service) Run(
 	runInfo := RunInfo{
 		Info:    workflow.GetInfo(ctx),
 		Environ: environ,
+		SysTime: workflow.Now(ctx),
 	}
 
 	plugins := starlark.StringDict{}

--- a/test/testdata/time_test.star
+++ b/test/testdata/time_test.star
@@ -1,4 +1,4 @@
-load("@plugin", "time", t = "test")
+load("@plugin", "os", "time", t = "test")
 
 def test_sleep():
     start_ts = time.time_ns()
@@ -15,3 +15,11 @@ def test_time():
     t.equal("float", type(seconds))
     datestr = time.utc_format_seconds("%Y-%m-%d", seconds)
     t.equal("string", type(datestr))
+
+def effective_time_test():
+    t.equal("unix:1753361232", os.environ["STARLARK_TIME"])
+    t.equal(float(1753361232), time.time())
+
+    sleep_seconds = 5
+    time.sleep(seconds = sleep_seconds)
+    t.equal(float(1753361232 + sleep_seconds), time.time())


### PR DESCRIPTION
This PR introduces the `STARLARK_TIME` environment variable, which can be used to alter the time for the Starlark script execution. This feature supports backfill scenarios, enabling users to execute their Starlark scripts as if they were triggered at a specific time in the past.

The STARLARK_TIME value must be in the following format: `unix:<value>`. Here, `unix` is the scheme, and `<value>` is a number of seconds since the epoch, commonly known as Unix time. For example, if the workflow execution is submitted with the `STARLARK_TIME=unix:1753788274`, then the date/time functions will behave as if the execution was submitted on Tuesday, July 29, 2025, at 11:24:34 AM UTC.

Currently, we only support Unix time format. However, we can add support for other formats, like RFC 3339.