### PR TITLE
chore: add PR quality check automation

### DIFF
--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -40,7 +40,6 @@ From https://cbea.ms/git-commit/#why-not-how:
    - Concrete, copyable commands with exact invocations
    - ✅ GOOD: `go test -v ./plugin/hashlib/... -run TestHashlib`
    - ❌ BAD: "Tested locally" or "See tests/foo_test.go"
-   - For integration tests: setup steps + commands
    - For integration tests: include Cadence setup steps + commands
 
 4. **Potential risks**

--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -1,0 +1,81 @@
+---
+title: PR Description Quality Standards
+description: Ensures PR descriptions meet starlark-worker quality criteria using guidance from PR template
+when: PR description is created or updated
+actions: Read PR template for guidance then report requirement status
+---
+
+# PR Description Quality Standards
+
+When evaluating a pull request description:
+
+1. **Read the PR template guidance** at `.github/pull_request_guidance.md` to understand the expected guidance for each section
+2. Apply that guidance to evaluate the current PR description
+3. Provide recommendations for how to improve the description.
+
+## Core Principle: Why Not How
+
+From https://cbea.ms/git-commit/#why-not-how:
+- **"A diff shows WHAT changed, but only the description can explain WHY"**
+- Focus on: the problem being solved, the reasoning behind the solution, context
+- The code itself documents HOW - the PR description documents WHY
+
+## Evaluation Criteria
+
+### Required Sections (must exist with substantive content per PR template guidance)
+
+1. **What changed?**
+   - 1-2 line summary of WHAT changed technically
+   - Focus on key modification, not implementation details
+   - Template has good/bad examples
+
+2. **Why?**
+   - Full context and motivation
+   - What problem does this solve? What's the use case?
+   - What's the impact if we don't make this change?
+   - **CRITICAL**: Technical rationale required for ALL changes (not just large ones)
+   - Must explain WHY this implementation approach was chosen
+
+3. **How did you test it?**
+   - Concrete, copyable commands with exact invocations
+   - ✅ GOOD: `go test -v ./plugin/hashlib/... -run TestHashlib`
+   - ❌ BAD: "Tested locally" or "See tests/foo_test.go"
+   - For integration tests: setup steps + commands
+   - For integration tests: include Cadence setup steps + commands
+
+4. **Potential risks**
+   - Plugin API compatibility concerns?
+   - Starlark sandbox or thread safety impact?
+   - Cadence SDK compatibility?
+   - Performance impact on concurrent or long-running workflows?
+
+5. **Release notes**
+   - If this completes a user-facing feature, describe it for Go module consumers and Starlark script authors
+   - Skip for: incremental work, internal refactors, partial implementations
+
+6. **Documentation Changes**
+   - README.md or CONTRIBUTING.md updates needed?
+   - New exported Go APIs documented via godoc?
+   - Starlark-facing changes need examples in testdata?
+   - Only mark N/A if certain no docs affected
+
+### Quality Checks
+
+- **Skip obvious things** - Don't flag items clear from folder structure
+- **Skip trivial refactors** - Minor formatting/style changes don't need deep rationale
+- **Don't check automated items** - Issue links, CI, linting are automated
+
+## FORBIDDEN - Never Include
+
+- ❌ "Issues Found", "Testing Evidence Quality", "Documentation Reasoning", "Summary" sections
+- ❌ "Note:" paragraphs or explanatory text outside recommendations
+- ❌ Grouping recommendations by type
+
+## Section Names (Use EXACT Brackets)
+
+- **[What changed?]**
+- **[Why?]**
+- **[How did you test it?]**
+- **[Potential risks]**
+- **[Release notes]**
+- **[Documentation Changes]**

--- a/.github/pull_request_guidance.md
+++ b/.github/pull_request_guidance.md
@@ -1,0 +1,62 @@
+<!-- 1-2 line summary of WHAT changed technically:
+- Always link the relevant GitHub issue, unless it is a minor bugfix
+- Good: "Added `hashlib` plugin with SHA-256 and MD5 support for Starlark scripts #42"
+- Bad: "added new plugin" -->
+**What changed?**
+
+
+<!-- Your goal is to provide all the required context for a future maintainer
+to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
+How did this work previously (and what was wrong with it)? What has changed, and why did you solve it
+this way?
+- Good: "Starlark scripts that need to hash data currently have no way to do so without
+  importing unsafe native Go code. This prevents multi-tenant environments from offering
+  common cryptographic utilities safely. This change adds a sandboxed `hashlib` plugin
+  that exposes SHA-256 and MD5 through the standard plugin registry, keeping the Starlark
+  sandbox intact while covering the most common hashing use cases."
+- Bad: "Adds hashing support" -->
+**Why?**
+
+
+<!-- Include specific test commands and setup. Please include the exact commands such that
+another maintainer or contributor can reproduce the test steps taken.
+- e.g. Unit test commands with exact invocation
+  `go test -v ./plugin/hashlib/... -run TestHashlib`
+- For integration tests against Cadence, include setup steps
+  Example: "Started local Cadence via Docker Compose, registered the default domain,
+  then ran `go test -v ./test/... -run TestCadenceIntegration`"
+- For Starlark script changes, include which testdata scripts were exercised
+  Example: "Ran `go test -v ./star/... -run TestExecFile` which exercises test/testdata/ping.star"
+- Good: Full commands that reviewers can copy-paste to verify
+- Bad: "Tested locally" or "Added tests" -->
+**How did you test it?**
+
+
+<!-- If there are risks that the release engineer or downstream consumers should know about,
+document them here. For example:
+- Has a plugin API changed? Will existing Starlark scripts break?
+- Has the workflow or activity registration signature changed? Is it backwards compatible?
+- Has a Cadence SDK dependency been bumped? Are there known breaking changes?
+- Could this affect Starlark sandbox safety or thread isolation?
+- Is there a performance concern for long-running or concurrent workflows?
+- If truly N/A, you can mark it as such -->
+**Potential risks**
+
+
+<!-- If this PR completes a user-facing feature or changes functionality, add release notes here.
+Your release notes should allow a Go module consumer or Starlark script author to understand
+the changes with little context. Always link the relevant GitHub issue when applicable.
+- For new plugins: describe the Starlark-facing API
+- For SDK version bumps: note the old and new versions
+- Skip for: incremental work, internal refactors, partial implementations -->
+**Release notes**
+
+
+<!-- Consider whether this change requires documentation updates:
+- Does the README.md need updating (new setup steps, changed CLI flags)?
+- Does CONTRIBUTING.md need updating (new dev workflow, changed test commands)?
+- Are new exported Go APIs documented via godoc comments for pkg.go.dev?
+- Do Starlark-facing changes need examples in testdata or doc comments?
+- Only mark N/A if you're certain no docs are affected -->
+**Documentation Changes**
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- If you are new to contributing or want a refresher, please read .github/pull_request_guidance.md -->
+**What changed?**
+
+
+**Why?**
+
+
+**How did you test it?**
+
+
+**Potential risks**
+
+
+**Release notes**
+
+
+**Documentation Changes**
+


### PR DESCRIPTION
## What changed?

Added PR quality check automation: PR template, guidance document, and Gitar rule for enforcing PR description standards.

## Why?

The starlark-worker repo had no PR template or description quality enforcement. Contributors had no structured guidance on what to include in PR descriptions, leading to inconsistent quality. This adds the same proven PR structure used in the cadence repo, adapted for starlark-worker's domain (Starlark plugins, sandbox safety, Cadence SDK compatibility, in-repo documentation).

The Gitar rule automates PR description review against these standards so quality feedback is consistent and doesn't depend solely on human reviewers.

## How did you test it?

Manual review of all three files for internal consistency:
- PR template section headings match the guidance document and Gitar rule
- Examples reference real starlark-worker packages (`plugin/hashlib`, `star`, `test/testdata`)
- Guidance is domain-appropriate (no cadence-server-specific concerns like schema migrations)

## Potential risks

N/A -- new files only, no code changes.

## Release notes

N/A -- internal project infrastructure.

## Documentation Changes

N/A -- these files are themselves documentation/process infrastructure.