### PR TITLE
Add getenv builtin to os plugin

### DIFF
--- a/plugin/os/module.go
+++ b/plugin/os/module.go
@@ -20,7 +20,9 @@ func (f *Module) Hash() (uint32, error)                 { return 0, fmt.Errorf("
 func (f *Module) Attr(n string) (starlark.Value, error) { return star.Attr(f, n, builtins, properties) }
 func (f *Module) AttrNames() []string                   { return star.AttrNames(builtins, properties) }
 
-var builtins = map[string]*starlark.Builtin{}
+var builtins = map[string]*starlark.Builtin{
+	"getenv": starlark.NewBuiltin("getenv", _getenv),
+}
 
 var properties = map[string]star.PropertyFactory{
 	"environ": environ,
@@ -29,3 +31,26 @@ var properties = map[string]star.PropertyFactory{
 func environ(receiver starlark.Value) (starlark.Value, error) {
 	return receiver.(*Module).environ, nil
 }
+
+// _getenv returns the value for the given key from the pipeline run environ,
+// or default if the key is absent.
+//
+// Returns: str or default
+func _getenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	m := fn.Receiver().(*Module)
+	var key string
+	defaultVal := starlark.Value(starlark.None)
+	if err := starlark.UnpackArgs("getenv", args, kwargs, "key", &key, "default?", &defaultVal); err != nil {
+		return starlark.None, err
+	}
+	v, found, err := m.environ.Get(starlark.String(key))
+	if err != nil {
+		return starlark.None, err
+	}
+	if !found {
+		return defaultVal, nil
+	}
+	return v, nil
+}
+
+

--- a/plugin/os/module_test.go
+++ b/plugin/os/module_test.go
@@ -1,0 +1,97 @@
+package os
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func newTestModule(t *testing.T, entries map[string]string) *Module {
+	t.Helper()
+	d := starlark.NewDict(len(entries))
+	for k, v := range entries {
+		require.NoError(t, d.SetKey(starlark.String(k), starlark.String(v)))
+	}
+	return &Module{environ: d}
+}
+
+func callGetenv(t *testing.T, m *Module, args starlark.Tuple) (starlark.Value, error) {
+	t.Helper()
+	attr, err := m.Attr("getenv")
+	require.NoError(t, err)
+	fn, ok := attr.(*starlark.Builtin)
+	require.True(t, ok, "expected getenv to be *starlark.Builtin")
+	thread := &starlark.Thread{Name: "test"}
+	return fn.CallInternal(thread, args, nil)
+}
+
+func TestModule_StarlarkValue(t *testing.T) {
+	m := newTestModule(t, nil)
+	require.Equal(t, pluginID, m.String())
+	require.Equal(t, pluginID, m.Type())
+	require.True(t, bool(m.Truth()))
+	_, err := m.Hash()
+	require.Error(t, err)
+	require.NotPanics(t, func() { m.Freeze() })
+}
+
+func TestModule_AttrNames(t *testing.T) {
+	m := newTestModule(t, nil)
+	names := m.AttrNames()
+	require.Contains(t, names, "getenv")
+	require.Contains(t, names, "environ")
+}
+
+func TestModule_EnvironAttr(t *testing.T) {
+	m := newTestModule(t, map[string]string{"FOO": "bar"})
+	v, err := m.Attr("environ")
+	require.NoError(t, err)
+	d, ok := v.(*starlark.Dict)
+	require.True(t, ok)
+	got, found, err := d.Get(starlark.String("FOO"))
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, starlark.String("bar"), got)
+}
+
+func TestModule_UnknownAttr(t *testing.T) {
+	m := newTestModule(t, nil)
+	v, err := m.Attr("does_not_exist")
+	require.NoError(t, err)
+	require.Nil(t, v)
+}
+
+func TestGetenv_KeyPresent(t *testing.T) {
+	m := newTestModule(t, map[string]string{"FOO": "bar"})
+	v, err := callGetenv(t, m, starlark.Tuple{starlark.String("FOO")})
+	require.NoError(t, err)
+	require.Equal(t, starlark.String("bar"), v)
+}
+
+func TestGetenv_KeyMissingNoDefault(t *testing.T) {
+	m := newTestModule(t, nil)
+	v, err := callGetenv(t, m, starlark.Tuple{starlark.String("MISSING")})
+	require.NoError(t, err)
+	require.Equal(t, starlark.None, v)
+}
+
+func TestGetenv_KeyMissingWithDefault(t *testing.T) {
+	m := newTestModule(t, nil)
+	v, err := callGetenv(t, m, starlark.Tuple{starlark.String("MISSING"), starlark.String("fallback")})
+	require.NoError(t, err)
+	require.Equal(t, starlark.String("fallback"), v)
+}
+
+func TestGetenv_PresentKeyIgnoresDefault(t *testing.T) {
+	m := newTestModule(t, map[string]string{"FOO": "bar"})
+	v, err := callGetenv(t, m, starlark.Tuple{starlark.String("FOO"), starlark.String("fallback")})
+	require.NoError(t, err)
+	require.Equal(t, starlark.String("bar"), v)
+}
+
+func TestGetenv_MissingKeyArg(t *testing.T) {
+	m := newTestModule(t, nil)
+	_, err := callGetenv(t, m, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read .github/pull_request_guidance.md -->
**What changed?**
 A new Starlark builtin os.getenv(key, default=None) that lets workflow code read a single key from the environ dict, without having to grab the full os.environ map and index
  into it.


**Why?**
 The environ property already exposed the whole dict, but callers wanting a single key had to write os.environ.get("FOO", default) or os.environ["FOO"]. os.getenv("FOO", 
  default) mirrors Python's os.getenv and is more ergonomic for the common single-key case. The environ data comes from PipelineRun spec.input.environ.

  Surface impact

  - Public Starlark API: new function os.getenv.
  - Go API: unchanged exports — _getenv and environ are unexported; only the Module and the Plugin registration are public.
  - Behavioral compatibility: purely additive; os.environ still works the same way.


**How did you test it?**
Unit test and end to end run

**Potential risks**


**Release notes**


**Documentation Changes**

